### PR TITLE
Add -Sec switch parameter for security attribute copying

### DIFF
--- a/Invoke-Robocopy/Invoke-Robocopy.Launcher.ps1
+++ b/Invoke-Robocopy/Invoke-Robocopy.Launcher.ps1
@@ -46,6 +46,8 @@ param(
 
     [Alias('MOVE')]
     [switch]$MoveFilesAndDirectories,
+    [switch]$Sec,
+
 
     [switch]$CopyAll,
 

--- a/Invoke-Robocopy/Invoke-Robocopy.psm1
+++ b/Invoke-Robocopy/Invoke-Robocopy.psm1
@@ -69,17 +69,23 @@ function Invoke-Robocopy {
         Move files and directories (delete from source after copying). Maps to /MOVE.
         Alias: MOVE
 
+    .PARAMETER Sec
+        Copy files with SECurity (equivalent to -CopyFlags D,A,T,S).
+        Automatically sets D (Data), A (Attributes), T (Timestamps), S (Security/NTFS ACLs).
+        Cannot be combined with -CopyFlags or -CopyAll.
+        Maps to /COPY:DATS.
+
     .PARAMETER CopyAll
         Copy all file attributes (equivalent to -CopyFlags D,A,T,S,O,U).
         Automatically sets D (Data), A (Attributes), T (Timestamps), S (Security/NTFS ACLs),
-        O (Owner info), U (aUditing info). Cannot be combined with -CopyFlags.
+        O (Owner info), U (aUditing info). Cannot be combined with -CopyFlags or -Sec.
         Maps to /COPY:DATSOU.
 
     .PARAMETER CopyFlags
         File attributes to copy. Default: D,A,T (Data, Attributes, Timestamps).
         Valid values: D (Data), A (Attributes), T (Timestamps), S (Security/NTFS ACLs),
         O (Owner info), U (aUditing info), X (skip alt data streams).
-        Maps to /COPY:flags. Cannot be combined with -CopyAll.
+        Maps to /COPY:flags. Cannot be combined with -Sec or -CopyAll.
 
     .PARAMETER DirectoryCopyFlags
         Directory attributes to copy. Default: D,A (Data, Attributes).
@@ -189,6 +195,11 @@ function Invoke-Robocopy {
         Recursive copy with all file attributes (Data, Attributes, Timestamps, Security, Owner, Auditing).
 
     .EXAMPLE
+        Invoke-Robocopy -Source C:\Data -Destination D:\Backup -Sec -Subdirectories
+
+        Recursive copy with security attributes (Data, Attributes, Timestamps, Security).
+
+    .EXAMPLE
         Invoke-Robocopy -Source C:\Data -Destination D:\Backup -MaxFileAgeDays 30 -PassThruResult
 
         Copy only files modified within the last 30 days and return structured result object.
@@ -264,6 +275,8 @@ function Invoke-Robocopy {
 
         [Alias('MOVE')]
         [switch]$MoveFilesAndDirectories,
+
+        [switch]$Sec,
 
         [switch]$CopyAll,
 
@@ -347,6 +360,10 @@ function Invoke-Robocopy {
 
         if ($PSBoundParameters.ContainsKey('MonitorSourceChanges') -xor $PSBoundParameters.ContainsKey('MonitorRunMinutes')) {
             throw "-MonitorSourceChanges and -MonitorRunMinutes must be used together."
+        }
+
+        if ($Sec -and ($CopyAll -or $PSBoundParameters.ContainsKey('CopyFlags'))) {
+            throw "-Sec cannot be combined with -CopyAll or -CopyFlags. Use one or the other."
         }
 
         if ($CopyAll -and $PSBoundParameters.ContainsKey('CopyFlags')) {

--- a/Invoke-Robocopy/Private/Robocopy.Helpers.ps1
+++ b/Invoke-Robocopy/Private/Robocopy.Helpers.ps1
@@ -52,7 +52,10 @@ function New-RobocopyArgumentList {
     if ($BoundParameters.ContainsKey('MaxFileAgeDays')) { $argumentList.Add("/MAXAGE:$($BoundParameters.MaxFileAgeDays)") }
     if ($BoundParameters.ContainsKey('MinFileAgeDays')) { $argumentList.Add("/MINAGE:$($BoundParameters.MinFileAgeDays)") }
 
-    if ($BoundParameters.ContainsKey('CopyAll')) {
+    if ($BoundParameters.ContainsKey('Sec')) {
+        $argumentList.Add('/COPY:DATS')
+    }
+    elseif ($BoundParameters.ContainsKey('CopyAll')) {
         $argumentList.Add('/COPY:DATSOU')
     }
     elseif ($BoundParameters.ContainsKey('CopyFlags')) {

--- a/Invoke-Robocopy/README.md
+++ b/Invoke-Robocopy/README.md
@@ -104,6 +104,11 @@ Invoke-Robocopy -Source C:\Data -Destination D:\Backup -LogPath C:\Logs\copy.log
 ### Copy all file attributes (Security, Owner, Auditing)
 ```powershell
 Invoke-Robocopy -Source C:\Data -Destination D:\Backup -CopyAll -Subdirectories
+### Copy with security attributes
+```powershell
+Invoke-Robocopy -Source C:\Data -Destination D:\Backup -Sec -Subdirectories
+```
+
 ```
 
 ## Parameter Sections
@@ -125,6 +130,7 @@ Invoke-Robocopy -Source C:\Data -Destination D:\Backup -CopyAll -Subdirectories
 - `Mirror` - Mirror source to destination (DESTRUCTIVE)
 - `MoveFiles` - Move files after copying
 - `MoveFilesAndDirectories` - Move files and directories
+- `Sec` - Copy with security attributes (D,A,T,S) - cannot combine with CopyFlags or CopyAll
 - `CopyAll` - Copy all file attributes (D,A,T,S,O,U) - cannot combine with CopyFlags
 - `CopyFlags` - File attributes to copy (custom selection)
 - `DirectoryCopyFlags` - Directory attributes to copy

--- a/Start-Robocopy.ps1
+++ b/Start-Robocopy.ps1
@@ -43,8 +43,13 @@ param(
 
 	[Alias('MOVE')]
 	[switch]$MoveFilesAndDirectories,
+	[switch]$Sec,
+
 
     [switch]$CopyAll,
+	[ValidateSet('D', 'A', 'T', 'S', 'O', 'U', 'X')]
+	[string[]]$CopyFlags = @('D', 'A', 'T'),
+
 
 	[ValidateSet('D', 'A', 'T', 'E', 'X')]
 	[string[]]$DirectoryCopyFlags = @('D', 'A'),


### PR DESCRIPTION
- Add -Sec switch that automatically selects D,A,T,S flags (Data, Attributes, Timestamps, Security)
- Implement validation to prevent combining -Sec with -CopyFlags or -CopyAll
- Update helper function to prioritize -Sec, then -CopyAll, then -CopyFlags
- Add comprehensive help documentation for -Sec parameter
- Update README with example usage and parameter documentation
- Sync launcher scripts with new parameter
- Fix missing CopyFlags parameter in Start-Robocopy.ps1
- Add example demonstrating -Sec usage for security-preserving copies

This feature provides a convenient shorthand for copying files with NTFS security attributes preserved without manually specifying individual flags or using the more comprehensive -CopyAll.