### PR TITLE
Add -Purge switch for destination cleanup support

### DIFF
--- a/Invoke-Robocopy/Invoke-Robocopy.Launcher.ps1
+++ b/Invoke-Robocopy/Invoke-Robocopy.Launcher.ps1
@@ -46,6 +46,8 @@ param(
 
     [Alias('MOVE')]
     [switch]$MoveFilesAndDirectories,
+
+    [switch]$Purge,
     [switch]$Sec,
 
 

--- a/Invoke-Robocopy/Invoke-Robocopy.psm1
+++ b/Invoke-Robocopy/Invoke-Robocopy.psm1
@@ -69,6 +69,10 @@ function Invoke-Robocopy {
         Move files and directories (delete from source after copying). Maps to /MOVE.
         Alias: MOVE
 
+    .PARAMETER Purge
+        Delete destination files and directories that no longer exist in source.
+        DESTRUCTIVE: Use with caution. Maps to /PURGE.
+
     .PARAMETER Sec
         Copy files with SECurity (equivalent to -CopyFlags D,A,T,S).
         Automatically sets D (Data), A (Attributes), T (Timestamps), S (Security/NTFS ACLs).
@@ -200,6 +204,11 @@ function Invoke-Robocopy {
         Recursive copy with security attributes (Data, Attributes, Timestamps, Security).
 
     .EXAMPLE
+        Invoke-Robocopy -Source C:\Data -Destination D:\Backup -Purge -WhatIf
+
+        Preview deleting destination-only items without executing changes.
+
+    .EXAMPLE
         Invoke-Robocopy -Source C:\Data -Destination D:\Backup -MaxFileAgeDays 30 -PassThruResult
 
         Copy only files modified within the last 30 days and return structured result object.
@@ -275,6 +284,8 @@ function Invoke-Robocopy {
 
         [Alias('MOVE')]
         [switch]$MoveFilesAndDirectories,
+
+        [switch]$Purge,
 
         [switch]$Sec,
 
@@ -376,7 +387,7 @@ function Invoke-Robocopy {
         $arguments = New-RobocopyArgumentList -BoundParameters $PSBoundParameters -Source $normalizedSource -Destination $normalizedDestination
 
         $activity = "Robocopy from '$normalizedSource' to '$normalizedDestination'"
-        $isDestructive = $Mirror -or $MoveFiles -or $MoveFilesAndDirectories
+        $isDestructive = $Mirror -or $MoveFiles -or $MoveFilesAndDirectories -or $Purge
         $action = if ($isDestructive) { 'Copy and delete destination/source items as configured' } else { 'Copy files' }
 
         if (-not $PSCmdlet.ShouldProcess($activity, $action)) {

--- a/Invoke-Robocopy/Private/Robocopy.Helpers.ps1
+++ b/Invoke-Robocopy/Private/Robocopy.Helpers.ps1
@@ -36,6 +36,7 @@ function New-RobocopyArgumentList {
     if ($BoundParameters.ContainsKey('Subdirectories')) { $argumentList.Add('/S') }
     if ($BoundParameters.ContainsKey('IncludeEmptySubdirectories')) { $argumentList.Add('/E') }
     if ($BoundParameters.ContainsKey('Mirror')) { $argumentList.Add('/MIR') }
+    if ($BoundParameters.ContainsKey('Purge')) { $argumentList.Add('/PURGE') }
     if ($BoundParameters.ContainsKey('MoveFiles')) { $argumentList.Add('/MOV') }
     if ($BoundParameters.ContainsKey('MoveFilesAndDirectories')) { $argumentList.Add('/MOVE') }
 

--- a/Invoke-Robocopy/README.md
+++ b/Invoke-Robocopy/README.md
@@ -104,11 +104,16 @@ Invoke-Robocopy -Source C:\Data -Destination D:\Backup -LogPath C:\Logs\copy.log
 ### Copy all file attributes (Security, Owner, Auditing)
 ```powershell
 Invoke-Robocopy -Source C:\Data -Destination D:\Backup -CopyAll -Subdirectories
+```
+
 ### Copy with security attributes
 ```powershell
 Invoke-Robocopy -Source C:\Data -Destination D:\Backup -Sec -Subdirectories
 ```
 
+### Purge destination-only items (preview first)
+```powershell
+Invoke-Robocopy -Source C:\Data -Destination D:\Backup -Purge -WhatIf
 ```
 
 ## Parameter Sections
@@ -128,6 +133,7 @@ Invoke-Robocopy -Source C:\Data -Destination D:\Backup -Sec -Subdirectories
 - `Subdirectories` - Copy subdirectories
 - `IncludeEmptySubdirectories` - Include empty subdirectories
 - `Mirror` - Mirror source to destination (DESTRUCTIVE)
+- `Purge` - Delete destination-only files/directories (DESTRUCTIVE)
 - `MoveFiles` - Move files after copying
 - `MoveFilesAndDirectories` - Move files and directories
 - `Sec` - Copy with security attributes (D,A,T,S) - cannot combine with CopyFlags or CopyAll

--- a/Start-Robocopy.ps1
+++ b/Start-Robocopy.ps1
@@ -43,6 +43,7 @@ param(
 
 	[Alias('MOVE')]
 	[switch]$MoveFilesAndDirectories,
+	[switch]$Purge,
 	[switch]$Sec,
 
 


### PR DESCRIPTION
- Add -Purge switch parameter to Invoke-Robocopy and launcher scripts
- Map -Purge to robocopy /PURGE in argument builder
- Treat -Purge as destructive for ShouldProcess (-WhatIf/-Confirm)
- Add comment-based help and example for Purge usage
- Update README examples and copy-section parameter reference